### PR TITLE
Upload code coverage to Codacy from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ before_install:
   # Since using JDK7 - prevent error downloading from Maven Central: Received fatal alert: protocol_version
   # See: https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/
   - alias mvn='mvn -Dhttps.protocols=TLSv1.2'
+script: mvn verify -B
+after_success:
+  # -- Codacy --
+  - mvn codacy:coverage -B

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.gavinmogan</groupId>
+        <artifactId>codacy-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <coverageReportFile>target/site/jacoco/jacoco.xml</coverageReportFile>
+          <apiToken>none</apiToken>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
- Use mvn verify goal instead of Travis-CI's default 'test'
  Reason: to generate the JaCoCo report xml file
- Use the codacy maven plugin to upload the code coverage results.
  Tried to use the Codacy command line tool for uploading the report
  but it was periodically failing to be downloaded from GitHub.