### PR TITLE
Deploy release version artifacts to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,15 @@ dist: precise
 jdk:
   - oraclejdk7
 before_install:
-  # Enable using aliases in a non-interactive bash script
-  # See: https://github.com/travis-ci/travis-ci/issues/2552
-  - shopt -s expand_aliases
-  # Since using JDK7 - prevent error downloading from Maven Central: Received fatal alert: protocol_version
-  # See: https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/
-  - alias mvn='mvn -Dhttps.protocols=TLSv1.2'
-script: mvn verify -B
+  - chmod +x .travis/mvn
+install: .travis/mvn install -DskipTests=true -Dmaven.javadoc.skip=true
+script: .travis/mvn verify
 after_success:
   # -- Codacy --
-  - mvn codacy:coverage -B
+  - .travis/mvn codacy:coverage
 deploy:
   provider: script
-  script: mvn deploy -s .travis/bintray-settings.xml -DskipTests -B -Dhttps.protocols=TLSv1.2
+  script: .travis/mvn deploy -s .travis/bintray-settings.xml -DskipTests
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,9 @@ script: mvn verify -B
 after_success:
   # -- Codacy --
   - mvn codacy:coverage -B
+deploy:
+  provider: script
+  script: mvn deploy -s .travis/bintray-settings.xml -DskipTests -B
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ after_success:
   - mvn codacy:coverage -B
 deploy:
   provider: script
-  script: mvn deploy -s .travis/bintray-settings.xml -DskipTests -B
+  script: mvn deploy -s .travis/bintray-settings.xml -DskipTests -B -Dhttps.protocols=TLSv1.2
   skip_cleanup: true
   on:
     tags: true

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -1,0 +1,47 @@
+# Travis-CI Integration
+
+## File Descriptions
+
+* [`.travis.yml`](../.travis.yml)  
+  The travis job configuration file
+* [`.travis/bintray-settings.xml`](bintray-settings.xml)  
+  Maven settings file specifically for the deployment phase to Bintray (see [Deployment](#deployment))
+* [`.travis/mvn`](mvn)  
+  A wrapper script with options and flags for `mvn` command line tool which are commonly used in Travis-CI
+
+## Job Phases
+
+### Install
+
+Build the code, skip tests and such
+
+### Test (i.e. `script`)
+
+Run tests and collect code coverage.
+
+### After Success
+
+Upload code coverage to Codacy.
+
+**Environment Variables**  
+
+| Name                   | Required | Secure | Description |
+| ---------------------- | :------: | :----: | ----------- |
+| `CODACY_PROJECT_TOKEN` | YES      | YES    | The token that identifies the target project in Codacy |   
+
+### Deployment
+
+Deploy release artifacts to [Bintray](https://bintray.com). 
+This phase should be executed only when a tag is pushed.
+Also, since Bintray supports only release versions, if the tag references a snapshot version, this phase will fail.
+
+**Environment Variables**  
+
+| Name                | Required | Secure | Description |
+| ------------------- | :------: | :----: | ----------- |
+| `BINTRAY_REPO_SLUG` | YES      | NO     | The slug of the target repository in Bintray. Expected format: `<subject>/<repo>` |
+| `BINTRAY_USER`      | YES      | NO     | The user to use for authentication when uploading the artifacts |
+| `BINTRAY_API_KEY`   | YES      | YES    | The API key of the user, used for authentication |
+| `BINTRAY_PUBLISH`   | NO       | NO     | Whether to publish the artifacts after they were uploaded successfully. Values: `0,1`, default: `0` | 
+| `BINTRAY_OVERRIDE`  | NO       | NO     | Whether to override existing artifacts (if any) when uploading. Values: `0,1`, default: `0` | 
+

--- a/.travis/bintray-settings.xml
+++ b/.travis/bintray-settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>bintray-maven-repo</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_API_KEY}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>default-bintray-publish</id>
+      <!-- Set default value for the BINTRAY_PUBLISH env variable if not defined -->
+      <activation>
+        <property>
+          <name>!env.BINTRAY_PUBLISH</name>
+        </property>
+      </activation>
+      <properties>
+        <env.BINTRAY_PUBLISH>0</env.BINTRAY_PUBLISH>
+      </properties>
+    </profile>
+    <profile>
+      <id>default-bintray-override</id>
+      <!-- Set default value for the BINTRAY_OVERRIDE env variable if not defined -->
+      <activation>
+        <property>
+          <name>!env.BINTRAY_OVERRIDE</name>
+        </property>
+      </activation>
+      <properties>
+        <env.BINTRAY_OVERRIDE>0</env.BINTRAY_OVERRIDE>
+      </properties>
+    </profile>
+  </profiles>
+
+</settings>

--- a/.travis/mvn
+++ b/.travis/mvn
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# mvn command wrapper script - with commonly used options and flags
+
+# Since using JDK7 - prevent error downloading from Maven Central: Received fatal alert: protocol_version
+# See: https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below/
+mvn -Dhttps.protocols=TLSv1.2 -B -V $@

--- a/pom.xml
+++ b/pom.xml
@@ -152,4 +152,12 @@
     </plugins>
   </build>
 
+  <distributionManagement>
+    <repository>
+      <id>bintray-maven-repo</id>
+      <!--suppress MavenModelInspection -->
+      <url>https://api.bintray.com/maven/${env.BINTRAY_REPO_SLUG}/commands-cli/;publish=${env.BINTRAY_PUBLISH};override=${env.BINTRAY_OVERRIDE}</url>
+    </repository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
Tagged release artifacts shall be deployed to Bintray from travis-ci.
For more information, refer to the [.travis/README.md](.travis/README.md) file.