### PR TITLE
Make maven central compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # commands-cli
 
-[ ![Download](https://api.bintray.com/packages/ebay/maven-oss/commands-cli/images/download.svg) ](https://bintray.com/ebay/maven-oss/commands-cli/_latestVersion)
+[![Download](https://api.bintray.com/packages/ebay/maven-oss/commands-cli/images/download.svg) ](https://bintray.com/ebay/maven-oss/commands-cli/_latestVersion)
+[![Javadocs](http://javadoc.io/badge/com.ebay.sd.commons/commands-cli.svg)](http://javadoc.io/doc/com.ebay.sd.commons/commands-cli)
 [![Build Status](https://travis-ci.org/eBay/commands-cli.svg?branch=master)](https://travis-ci.org/eBay/commands-cli)
 [![Code Quality](https://api.codacy.com/project/badge/Grade/1b1f6836a8b74f56b212f53b281215ee)](https://www.codacy.com/app/eBay/commands-cli?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=eBay/commands-cli&amp;utm_campaign=Badge_Grade)
 [![Code Coverage](https://api.codacy.com/project/badge/Coverage/1b1f6836a8b74f56b212f53b281215ee)](https://www.codacy.com/app/eBay/commands-cli?utm_source=github.com&utm_medium=referral&utm_content=eBay/commands-cli&utm_campaign=Badge_Coverage)
-[![GitHub](https://img.shields.io/github/license/ebay/commands-cli.svg)](LICENSE.txt)
+[![License](https://img.shields.io/github/license/ebay/commands-cli.svg)](LICENSE.txt)
 
 An opinionated extension to the [Apache Commons CLI](https://commons.apache.org/proper/commons-cli/) library which adds support for commands.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.ebay.sd.commons</groupId>
   <artifactId>commands-cli</artifactId>
-  <version>0.7.1-SNAPSHOT</version>
+  <version>0.7.1</version>
   <name>Commands CLI</name>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,16 @@
 
   <groupId>com.ebay.sd.commons</groupId>
   <artifactId>commands-cli</artifactId>
-  <version>0.7.0</version>
+  <version>0.7.1-SNAPSHOT</version>
   <name>Commands CLI</name>
   <packaging>jar</packaging>
+
+  <description>An opinionated extension to the Apache Commons CLI library which adds support for commands</description>
+  <url>https://github.com/eBay/commands-cli</url>
+  <scm>
+    <url>https://github.com/eBay/commands-cli</url>
+    <connection>scm:git:https://github.com/eBay/commands-cli</connection>
+  </scm>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,19 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
         <configuration>

--- a/src/main/java/com/ebay/sd/commons/cli/AbstractCommand.java
+++ b/src/main/java/com/ebay/sd/commons/cli/AbstractCommand.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.util.Objects.requireNonNull;
@@ -34,6 +33,7 @@ public abstract class AbstractCommand implements Command {
    * Construct a command
    *
    * @param commandContext the command context
+   * @throws ParseException if the the input is invalid
    */
   protected AbstractCommand(CommandContext commandContext) throws ParseException {
     this.commandContext = requireNonNull(commandContext, "commandContext is required");

--- a/src/main/java/com/ebay/sd/commons/cli/Argument.java
+++ b/src/main/java/com/ebay/sd/commons/cli/Argument.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.util.Objects.requireNonNull;
@@ -26,16 +25,15 @@ import org.apache.commons.cli.Option;
  *       .description("The input file")
  *       .required()
  *       .build()
- *   </pre>
+ * </pre>
  * It is then can be added to the command descriptor using:
  * <pre>
  *     .addCommand(fileArg)
- *   </pre>
+ * </pre>
  * To get the argument value during command execution, use the {@link CommandContext}. For example:
  * <pre>
- *     String file = commandContext.getArgumentValue("FILE");
- *   </pre>
- * </p>
+ *   String file = commandContext.getArgumentValue("FILE");
+ * </pre>
  *
  * @see CommandDescriptor.Builder#addArgument(Argument)
  * @see CommandContext#getArgumentValue(String)
@@ -87,6 +85,8 @@ public class Argument implements NameDescriptionSupport {
 
   /**
    * Get whether this argument is defined as required
+   *
+   * @return <tt>true</tt> if this argument is required, <tt>false</tt> otherwise
    */
   public boolean isRequired() {
     return required;
@@ -98,6 +98,8 @@ public class Argument implements NameDescriptionSupport {
    * <p>
    * This is either a positive value (<tt>&gt;0</tt>) or equals to {@link #UNLIMITED_VALUES}.
    * </p>
+   *
+   * @return the multiplicity of this argument
    */
   public int getMultiplicity() {
     return multiplicity;

--- a/src/main/java/com/ebay/sd/commons/cli/CommandContext.java
+++ b/src/main/java/com/ebay/sd/commons/cli/CommandContext.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.util.Objects.requireNonNull;
@@ -36,6 +35,8 @@ public class CommandContext {
 
   /**
    * Get the parsed command line
+   *
+   * @return the command line
    */
   public CommandLine getCommandLine() {
     return commandLine;
@@ -43,6 +44,8 @@ public class CommandContext {
 
   /**
    * Get the resolved command route
+   *
+   * @return the command route
    */
   public CommandRoute getCommandRoute() {
     return commandRoute;
@@ -72,6 +75,7 @@ public class CommandContext {
    * Get a context value, or default value if was not set
    *
    * @param key the key that identifies the value to get
+   * @param defaultValue the default value to return in case a value is missing for the given <tt>key</tt>
    * @return the value, or default value
    */
   public Object getValue(String key, Object defaultValue) {
@@ -114,6 +118,7 @@ public class CommandContext {
    * If the argument has multiple values, the first value is returned.
    *
    * @param name the name of the argument
+   * @param defaultValue the default value to return in case a value is missing for the given <tt>name</tt>
    * @return the value, or default
    */
   public String getArgumentValue(String name, String defaultValue) {

--- a/src/main/java/com/ebay/sd/commons/cli/CommandDescriptor.java
+++ b/src/main/java/com/ebay/sd/commons/cli/CommandDescriptor.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.lang.String.format;
@@ -29,8 +28,7 @@ import org.apache.commons.cli.ParseException;
  *         .addArgument(fileArg)
  *         .factory(fooCmdFactory)
  *         .build();
- *   </pre>
- * </p>
+ * </pre>
  */
 public class CommandDescriptor extends Descriptor {
 
@@ -105,7 +103,6 @@ public class CommandDescriptor extends Descriptor {
      * <li>Argument with unlimited values must be last</li>
      * <li>An optional argument (non-required) must be last</li>
      * </ul>
-     * </p>
      *
      * @param argument the argument to add
      * @return this builder

--- a/src/main/java/com/ebay/sd/commons/cli/CommandRoute.java
+++ b/src/main/java/com/ebay/sd/commons/cli/CommandRoute.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static com.ebay.sd.commons.cli.Utils.join;
@@ -57,6 +56,8 @@ public class CommandRoute {
 
   /**
    * Get the full path this command route holds as string
+   *
+   * @return the full path of this command route
    */
   public String getFullPathAsString() {
     List<String> parts = new ArrayList<>(path.size() + 1);

--- a/src/main/java/com/ebay/sd/commons/cli/CommandsCliMain.java
+++ b/src/main/java/com/ebay/sd/commons/cli/CommandsCliMain.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.util.Objects.requireNonNull;
@@ -31,8 +30,7 @@ import org.apache.commons.cli.ParseException;
  *           .build()
  *           .main(args)
  *     }
- *   </pre>
- * </p>
+ * </pre>
  */
 public class CommandsCliMain {
 

--- a/src/main/java/com/ebay/sd/commons/cli/RouteDescriptor.java
+++ b/src/main/java/com/ebay/sd/commons/cli/RouteDescriptor.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static java.util.Collections.unmodifiableList;
@@ -28,8 +27,7 @@ import java.util.Map;
  *         .addSubCommand(BarCommand.DESCRIPTOR)
  *         .addSubCommand(RouteDescriptor.builder("baz") ... .build())
  *         .build();
- *   </pre>
- * </p>
+ * </pre>
  */
 public class RouteDescriptor extends Descriptor {
 

--- a/src/main/java/com/ebay/sd/commons/cli/UsageHelp.java
+++ b/src/main/java/com/ebay/sd/commons/cli/UsageHelp.java
@@ -6,7 +6,6 @@ Use of this source code is governed by an Apache-2.0-style
 license that can be found in the LICENSE.txt file or at
 http://www.apache.org/licenses/LICENSE-2.0.
 ************************************************************/
-
 package com.ebay.sd.commons.cli;
 
 import static com.ebay.sd.commons.cli.Utils.pad;
@@ -53,7 +52,6 @@ import org.apache.commons.cli.Options;
  *    bar   The bar command
  *    baz   The baz command
  * </pre>
- * </p>
  */
 public class UsageHelp {
 


### PR DESCRIPTION
In order to be able to upload artifacts to Maven Central, some fields had to be added to the pom and a javadoc jar needed to be generated.
Also, after the artifacts are released to Maven Central, the javadoc is automatically available from [javadoc.io](https://javadoc.io). So the readme now also includes a javadoc badge pointing to the javadoc of latest version.